### PR TITLE
chore: improve readme steps

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[{Makefile,**.mk}]
+indent_style = tab
+indent_size = 4
+
+[*.{diff,md}]
+trim_trailing_whitespace = false

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+setup/current_shell:
+	@echo "Updating current shell fs.aio-max-nr";
+	@sudo sysctl --write fs.aio-max-nr=1048576 --quiet;
+	@echo "New fs.aio-max-nr value for current shell is: $$(sysctl fs.aio-max-nr | awk '{print $$3}')";
+	@echo "Finished current shell setup";
+
+setup/permanent:
+	@echo "Writing permanent config on '/etc/sysctl.d/41-aio_max_nr.conf'";
+	@echo fs.aio-max-nr=1048576 | sudo tee /etc/sysctl.d/41-aio_max_nr.conf > /dev/null;
+	@sudo sysctl --load '/etc/sysctl.d/41-aio_max_nr.conf' > /dev/null;
+	@echo "New fs.aio-max-nr value for permanent shell is: $$(sysctl fs.aio-max-nr | awk '{print $$3}')";
+	@echo "Finished permanent config setup";
+
+.PHONY: setup
+setup:
+	@echo "Checking current fs.aio-max-nr value..."
+	@CURRENT_VALUE=$$(sysctl fs.aio-max-nr | awk '{print $$3}'); \
+	if [ $$CURRENT_VALUE -ge 1048576 ]; then \
+		echo "Current fs.aio-max-nr value is: $$CURRENT_VALUE"; \
+		echo "Setup unnecessary"; \
+	else \
+		echo "Current fs.aio-max-nr value is: $$CURRENT_VALUE"; \
+		$(MAKE) --silent --no-print-directory setup/current_shell; \
+		$(MAKE) --silent --no-print-directory setup/permanent; \
+		echo "Setup successful"; \
+	fi

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Before you begin, make sure the following software is installed on your system:
 - [Docker](https://docs.docker.com/engine/install/ubuntu/)
 - [Docker Compose](https://docs.docker.com/compose/install/linux/)
 
+> [!NOTE]
+> The Docker's commands listed below consider when you use its Docker V2
+
 ## Getting Started
 
 ### **Clone this repository**
@@ -21,7 +24,13 @@ git clone https://github.com/gvieira18/ws-scylla.git
 
 Before starting the cluster, ensure the [fs.aio-max-nr](https://www.kernel.org/doc/Documentation/sysctl/fs.txt) value is sufficient (e.g. `1048576` or `2097152` or more).
 
-To check the actual value, use one of the following commands:
+You can use the Makefile setup command to configure the `fs.aio-max-nr` value. It will set the value to `1048576`, which is the minimum recommended for clusters.
+
+```sh
+make setup
+```
+
+If you prefer to configure it manually, run one of the following commands to check the current value:
 
 ```sh
 sysctl --all | grep --word-regexp -- 'aio-max-nr'


### PR DESCRIPTION
This PR improves some steps to run the cluster on docker.

#### Changes

- Update **Heading** topics to future table of contents (TOC)
- Update setup to reload only the `fs.aio-max-nr` file instead of reloading all files
- Adds command for temporary `fs.aio-max-nr` setup
- Start support for Makefile commands