### PR TITLE
chore: improve makefile usage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,7 @@ indent_size = 4
 
 [*.{diff,md}]
 trim_trailing_whitespace = false
+
+[docker-compose{,.*}.{yaml,yml}]
+indent_style = space
+indent_size = 2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "files.associations": {
+    "Makefile.setup": "makefile",
+    "Makefile.singlenode": "makefile",
+    "network.compose.yml": "dockercompose",
+    "single-node.compose.yml": "dockercompose"
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,15 @@
-setup/current_shell:
-	@echo "Updating current shell fs.aio-max-nr";
-	@sudo sysctl --write fs.aio-max-nr=1048576 --quiet;
-	@echo "New fs.aio-max-nr value for current shell is: $$(sysctl fs.aio-max-nr | awk '{print $$3}')";
-	@echo "Finished current shell setup";
+DOCKER_COMMAND := $(shell command -v docker 2> /dev/null)
 
-setup/permanent:
-	@echo "Writing permanent config on '/etc/sysctl.d/41-aio_max_nr.conf'";
-	@echo fs.aio-max-nr=1048576 | sudo tee /etc/sysctl.d/41-aio_max_nr.conf > /dev/null;
-	@sudo sysctl --load '/etc/sysctl.d/41-aio_max_nr.conf' > /dev/null;
-	@echo "New fs.aio-max-nr value for permanent shell is: $$(sysctl fs.aio-max-nr | awk '{print $$3}')";
-	@echo "Finished permanent config setup";
+ifndef DOCKER_COMMAND
+$(error "Cannot find docker")
+endif
 
-.PHONY: setup
-setup:
-	@echo "Checking current fs.aio-max-nr value..."
-	@CURRENT_VALUE=$$(sysctl fs.aio-max-nr | awk '{print $$3}'); \
-	if [ $$CURRENT_VALUE -ge 1048576 ]; then \
-		echo "Current fs.aio-max-nr value is: $$CURRENT_VALUE"; \
-		echo "Setup unnecessary"; \
-	else \
-		echo "Current fs.aio-max-nr value is: $$CURRENT_VALUE"; \
-		$(MAKE) --silent --no-print-directory setup/current_shell; \
-		$(MAKE) --silent --no-print-directory setup/permanent; \
-		echo "Setup successful"; \
-	fi
+include makefiles/Makefile.setup
+include makefiles/Makefile.singlenode
+
+.PHONY: help
+help: ## Show the help commands
+	@echo "Available commands:"
+	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+	awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-35s\033[0m %s\n", $$1, $$2}' | \
+	sort

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ include makefiles/Makefile.singlenode
 .PHONY: help
 help: ## Show the help commands
 	@echo "Available commands:"
-	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
-	awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-35s\033[0m %s\n", $$1, $$2}' | \
+	@grep -E '^[^[:space:]]+:[^:]*?## .*$$' $(MAKEFILE_LIST) | \
+	sed -e 's/^[^:]*://g' | \
+	awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2}' | \
 	sort

--- a/docker/network.compose.yml
+++ b/docker/network.compose.yml
@@ -1,0 +1,10 @@
+networks:
+  scylla-dc:
+    name: scylla-dc
+    driver: bridge
+    ipam:
+      config:
+        - gateway: 10.9.8.1
+          subnet: 10.9.8.0/24
+    driver_opts:
+      com.docker.network.bridge.name: scylla-dc

--- a/docker/single-node.compose.yml
+++ b/docker/single-node.compose.yml
@@ -1,0 +1,27 @@
+services:
+  scylla-1:
+    image: scylladb/scylla:6.0
+    container_name: scylla-1
+    command:
+      - --smp=1
+      - --memory=2GB
+      - --overprovisioned=1
+      - --developer-mode=1
+      - --seeds=scylla-1
+    ports:
+      - 9042:9042
+    networks:
+      scylla-dc: null
+    volumes:
+      - scylla-1:/var/lib/scylla
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - cqlsh -e "SHOW VERSION" || exit 1
+      interval: 15s
+      timeout: 30s
+      retries: 15
+      start_period: 30s
+volumes:
+  scylla-1:
+    name: scylla-1

--- a/makefiles/Makefile.setup
+++ b/makefiles/Makefile.setup
@@ -1,0 +1,30 @@
+.PHONY: setup
+setup: ## Validate the "fs.aio-max-nr" value
+	@echo "Checking current fs.aio-max-nr value..."
+	@CURRENT_VALUE=$$(sysctl fs.aio-max-nr | awk '{print $$3}'); \
+	if [ $$CURRENT_VALUE -ge 1048576 ]; then \
+		echo "Current fs.aio-max-nr value is: $$CURRENT_VALUE"; \
+		echo "Setup unnecessary"; \
+	else \
+		echo "Current fs.aio-max-nr value is: $$CURRENT_VALUE"; \
+		echo "Performing setup..."; \
+		$(MAKE) --silent --no-print-directory _setup_current_shell; \
+		$(MAKE) --silent --no-print-directory _setup_permanent; \
+		echo "Setup successful"; \
+	fi
+
+# Private targets for setup
+.PHONY: _setup_current_shell _setup_permanent
+
+_setup_current_shell:
+	@echo "Updating current shell fs.aio-max-nr";
+	@sudo sysctl --write fs.aio-max-nr=1048576 --quiet;
+	@echo "New fs.aio-max-nr value for current shell is: $$(sysctl fs.aio-max-nr | awk '{print $$3}')";
+	@echo "Finished current shell setup";
+
+_setup_permanent:
+	@echo "Writing permanent config on '/etc/sysctl.d/41-aio_max_nr.conf'";
+	@echo fs.aio-max-nr=1048576 | sudo tee /etc/sysctl.d/41-aio_max_nr.conf > /dev/null;
+	@sudo sysctl --load '/etc/sysctl.d/41-aio_max_nr.conf' > /dev/null;
+	@echo "New fs.aio-max-nr value for permanent configuration is: $$(sysctl fs.aio-max-nr | awk '{print $$3}')";
+	@echo "Finished permanent config setup";

--- a/makefiles/Makefile.singlenode
+++ b/makefiles/Makefile.singlenode
@@ -1,0 +1,27 @@
+COMPOSE_SINGLE_NODE_FLAGS = --file docker/network.compose.yml --file docker/single-node.compose.yml
+
+NODE_1 = scylla-1
+
+.PHONY: stats
+stats: ## Enter on docker compose stats
+	@$(DOCKER_COMMAND) compose stats
+
+.PHONY: status
+status: ## Show docker status on format "ID NAME STATE IMAGE STATUS PORTS"
+	@$(DOCKER_COMMAND) ps --format='table {{.ID}}\t{{.Names}}\t{{.State}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}'
+
+.PHONY: single-node-up
+single-node-up: ## Starts a single-node ScyllaDB
+	@$(DOCKER_COMMAND) compose $(COMPOSE_SINGLE_NODE_FLAGS) up --detach
+
+.PHONY: single-node-down
+single-node-down: ## Remove the entire container with volumes from single-node
+	@$(DOCKER_COMMAND) compose $(COMPOSE_SINGLE_NODE_FLAGS) down --volumes
+
+.PHONY: single-node-nt-status
+single-node-nt-status: ## Shows single-node nodetool status
+	@$(DOCKER_COMMAND) compose $(COMPOSE_SINGLE_NODE_FLAGS) exec -it $(NODE_1) nodetool status
+
+.PHONY: single-node-cqlsh
+single-node-cqlsh: ## Enters single-node CQLSH
+	@$(DOCKER_COMMAND) compose $(COMPOSE_SINGLE_NODE_FLAGS) exec -it $(NODE_1) cqlsh


### PR DESCRIPTION
This PR improves some uses with Makefile.

#### Changes

- Add help target
- Separating concerns between Makefiles
  - Makefile.setup: Check and configure (if necessary) the `fs.aio-max-nr` parameter
  - Makefile.singlenode: Start a single ScyllaDB node, useful if you need to validate a poc or check a cqlsh command which does not depend on clustering

![image](https://github.com/user-attachments/assets/4e5ad478-5352-4239-a08c-5b1ddad47dfc)